### PR TITLE
Fixing used_words condition in update function

### DIFF
--- a/chacha20_drng.c
+++ b/chacha20_drng.c
@@ -426,7 +426,7 @@ static inline void drng_chacha20_update(struct chacha20_state *chacha20,
 {
 	uint32_t i, tmp[CHACHA20_BLOCK_SIZE_WORDS];
 
-	if (used_words > CHACHA20_KEY_SIZE_WORDS) {
+	if (CHACHA20_BLOCK_SIZE_WORDS - used_words < CHACHA20_KEY_SIZE_WORDS) {
 		chacha20_block(&chacha20->constants[0], tmp);
 		for (i = 0; i < CHACHA20_KEY_SIZE_WORDS; i++)
 			chacha20->key.u[i] ^= le_bswap32(tmp[i]);


### PR DESCRIPTION
The `if` condition in the `drng_chacha20_update` checks if the `buf` has enough words to be consumed using following condition

  `if (used_words >  CHACHA20_KEY_SIZE_WORDS) {`

However the condition should be:

  `if (CHACHA20_BLOCK_SIZE_WORDS - used_words < CHACHA20_KEY_SIZE_WORDS) {`

The values for `CHACHA20_BLOCK_SIZE_WORDS` and `CHACHA20_KEY_SIZE_WORDS` are 16 and 8. Due to these particular values, the current condition also works. However the condition I am proposing here is better for readability.